### PR TITLE
Forbid cross linking CCS and census QIDs

### DIFF
--- a/census_rm_ops_ui/controllers/case_controller.py
+++ b/census_rm_ops_ui/controllers/case_controller.py
@@ -37,6 +37,18 @@ def get_all_case_details(case_id, case_api_url):
     return response.json()
 
 
+def get_summary_case_details(case_id, case_api_url):
+    logger.debug('Getting all case details', case_id=case_id)
+    response = requests.get(f'{case_api_url}/cases/{urllib.parse.quote(case_id)}')
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        logger.error('Error searching for summary details of case', case_id=case_id)
+        raise
+
+    return response.json()
+
+
 def get_qid(qid, case_api_url):
     logger.debug('Getting qid details', qid=qid, user=g.get('user'))
     response = requests.get(f'{case_api_url}/qids/{urllib.parse.quote(qid)}')

--- a/census_rm_ops_ui/views/case_details.py
+++ b/census_rm_ops_ui/views/case_details.py
@@ -23,19 +23,7 @@ def case_details_results():
 
 def is_ccs_type_qid(qid):
     qid_type = qid[:2]
-    return {
-        '51': True,
-        '52': True,
-        '53': True,
-        '54': True,
-        '61': True,
-        '62': True,
-        '63': True,
-        '71': True,
-        '73': True,
-        '81': True,
-        '83': True,
-    }.get(qid_type, False)
+    return qid_type in {'51', '52', '53', '54', '61', '62', '63', '71', '73', '81', '83', }
 
 
 @case_details_bp.route('/link-qid/')

--- a/tests/views/test_case_details.py
+++ b/tests/views/test_case_details.py
@@ -50,6 +50,7 @@ def test_case_details_results(app_test_client):
 def test_get_qid_for_linking(app_test_client):
     # Given
     case_id = str(uuid.uuid4())
+    url_safe_case_id = urllib.parse.quote(case_id)
     qid = '1234567890'
 
     qid_payload = {
@@ -57,9 +58,17 @@ def test_get_qid_for_linking(app_test_client):
         'questionnaireId': qid,
     }
 
+    case_summary_payload = {
+        'id': case_id,
+        'surveyType': 'CENSUS',
+    }
+
     # Mock the case API response
     responses.add(responses.GET, f'{TestConfig.CASE_API_URL}/qids/{qid}',
                   body=json.dumps(qid_payload))
+
+    responses.add(responses.GET, f'{TestConfig.CASE_API_URL}/cases/{url_safe_case_id}',
+                  body=json.dumps(case_summary_payload))
     # When
     response = app_test_client.get(f'case-details/link-qid/?qid={qid}&case_id={case_id}')
 
@@ -110,6 +119,112 @@ def test_get_qid_failed_linking(app_test_client):
     # Then
     unittest_helper.assertEqual(response.status_code, 200)
     unittest_helper.assertIn('QID does not exist in RM'.encode(), response.data)
+
+
+@responses.activate
+def test_ccs_qid_link_to_non_ccs_case_is_forbidden(app_test_client):
+    # Given
+    case_id = str(uuid.uuid4())
+    ccs_qid = '7134567890'
+    url_safe_case_id = urllib.parse.quote(case_id)
+
+    qid_payload = {
+        'caseId': case_id,
+        'questionnaireId': ccs_qid,
+    }
+
+    case_details_payload = {
+        'id': case_id,
+        'organisationName': 'test_org',
+        'addressLine1': 'Somewhere',
+        'addressLine2': 'Over The',
+        'addressLine3': 'Rainbow',
+        'townName': 'Newport',
+        'postcode': 'XX0 0XX',
+        'caseType': 'HH',
+        'addressLevel': 'U',
+        'estabType': 'HOUSEHOLD',
+        'caseRef': '123456789',
+        'events': [{'id': '14063759-c608-4f9f-8fa5-988f52260d7f', 'eventType': 'SAMPLE_LOADED',
+                    'rmEventProcessed': '2020-08-26T07:38:47.453158Z',
+                    'eventDescription': 'Create case sample received', 'eventDate': '2020-08-26T07:38:47.453158Z',
+                    'type': 'None', 'channel': 'RM', 'transactionId': 'None',
+                    'eventPayload': '{\"testKey\": \"testValue\"}'}, ]
+    }
+
+    case_summary_payload = {
+        'id': case_id,
+        'surveyType': 'CENSUS',
+    }
+
+    # Mock the case API response
+    responses.add(responses.GET, f'{TestConfig.CASE_API_URL}/qids/{ccs_qid}',
+                  body=json.dumps(qid_payload))
+
+    responses.add(responses.GET, f'{TestConfig.CASE_API_URL}/cases/case-details/{url_safe_case_id}',
+                  body=json.dumps(case_details_payload))
+
+    responses.add(responses.GET, f'{TestConfig.CASE_API_URL}/cases/{url_safe_case_id}',
+                  body=json.dumps(case_summary_payload))
+    # When
+    response = app_test_client.get(f'case-details/link-qid/?qid={ccs_qid}&case_id={case_id}', follow_redirects=True)
+
+    # Then
+    unittest_helper.assertEqual(response.status_code, 200)
+    unittest_helper.assertIn('Linking a CCS QID to a non CCS case is forbidden'.encode(), response.data)
+
+
+@responses.activate
+def test_census_qid_link_to_ccs_case_is_forbidden(app_test_client):
+    # Given
+    case_id = str(uuid.uuid4())
+    qid = '0134567890'
+    url_safe_case_id = urllib.parse.quote(case_id)
+
+    qid_payload = {
+        'caseId': case_id,
+        'questionnaireId': qid,
+    }
+
+    case_details_payload = {
+        'id': case_id,
+        'organisationName': 'test_org',
+        'addressLine1': 'Somewhere',
+        'addressLine2': 'Over The',
+        'addressLine3': 'Rainbow',
+        'townName': 'Newport',
+        'postcode': 'XX0 0XX',
+        'caseType': 'HH',
+        'addressLevel': 'U',
+        'estabType': 'HOUSEHOLD',
+        'caseRef': '123456789',
+        'events': [{'id': '14063759-c608-4f9f-8fa5-988f52260d7f', 'eventType': 'SAMPLE_LOADED',
+                    'rmEventProcessed': '2020-08-26T07:38:47.453158Z',
+                    'eventDescription': 'Create case sample received', 'eventDate': '2020-08-26T07:38:47.453158Z',
+                    'type': 'None', 'channel': 'RM', 'transactionId': 'None',
+                    'eventPayload': '{\"testKey\": \"testValue\"}'}, ]
+    }
+
+    case_summary_payload = {
+        'id': case_id,
+        'surveyType': 'CCS',
+    }
+
+    # Mock the case API response
+    responses.add(responses.GET, f'{TestConfig.CASE_API_URL}/qids/{qid}',
+                  body=json.dumps(qid_payload))
+
+    responses.add(responses.GET, f'{TestConfig.CASE_API_URL}/cases/case-details/{url_safe_case_id}',
+                  body=json.dumps(case_details_payload))
+
+    responses.add(responses.GET, f'{TestConfig.CASE_API_URL}/cases/{url_safe_case_id}',
+                  body=json.dumps(case_summary_payload))
+    # When
+    response = app_test_client.get(f'case-details/link-qid/?qid={qid}&case_id={case_id}', follow_redirects=True)
+
+    # Then
+    unittest_helper.assertEqual(response.status_code, 200)
+    unittest_helper.assertIn('Linking a non CCS QID to a CCS case is forbidden'.encode(), response.data)
 
 
 @responses.activate

--- a/tests/views/test_case_details.py
+++ b/tests/views/test_case_details.py
@@ -2,6 +2,7 @@ import json
 import urllib
 import uuid
 
+import pytest
 import responses
 
 from config import TestConfig
@@ -122,10 +123,22 @@ def test_get_qid_failed_linking(app_test_client):
 
 
 @responses.activate
-def test_ccs_qid_link_to_non_ccs_case_is_forbidden(app_test_client):
+@pytest.mark.parametrize('ccs_qid', [
+    '5100000000',
+    '5234567890',
+    '5334567890',
+    '5434567890',
+    '6134567890',
+    '6234567890',
+    '6334567890',
+    '7134567890',
+    '7334567890',
+    '8134567890',
+    '8334567890',
+])
+def test_ccs_qid_link_to_non_ccs_case_is_forbidden(app_test_client, ccs_qid):
     # Given
     case_id = str(uuid.uuid4())
-    ccs_qid = '7134567890'
     url_safe_case_id = urllib.parse.quote(case_id)
 
     qid_payload = {
@@ -175,10 +188,16 @@ def test_ccs_qid_link_to_non_ccs_case_is_forbidden(app_test_client):
 
 
 @responses.activate
-def test_census_qid_link_to_ccs_case_is_forbidden(app_test_client):
+@pytest.mark.parametrize('qid', [
+    '0100000000',
+    '0234567890',
+    '1134567890',
+    '2334567890',
+    '3134567890',
+])
+def test_census_qid_link_to_ccs_case_is_forbidden(app_test_client, qid):
     # Given
     case_id = str(uuid.uuid4())
-    qid = '0134567890'
     url_safe_case_id = urllib.parse.quote(case_id)
 
     qid_payload = {


### PR DESCRIPTION
# Motivation and Context
We want to protect against CCS and census material being cross linked in the Ops UI

# What has changed
* Flash an error and don't submit links between CCS/census cases and material
* New controller for calling case API endpoint
* Tests

# How to test?
Run against linked AT branch

# Links
https://trello.com/c/BH1zjT7o/2224-rops-ui-protect-against-ccs-census-qid-mismatched-links-5
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/386